### PR TITLE
Add data_loader notebook for text cleaning and dataset balancing

### DIFF
--- a/data_loader.ipynb
+++ b/data_loader.ipynb
@@ -1,0 +1,139 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0e92b4e5",
+   "metadata": {},
+   "source": [
+    "#  Toxic Comment Data Loader\n",
+    "\n",
+    "prepares and cleans the Jigsaw toxic comment dataset for model training.\n",
+    "- cleans HTML, emojis, whitespace, and URLs\n",
+    "- balances toxic vs non-toxic samples\n",
+    "- logs key values\n",
+    "- returns a balanced and cleaned DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5402a980",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import re\n",
+    "import html\n",
+    "import emoji\n",
+    "\n",
+    "TOXIC_LABELS = ['toxic', 'severe_toxic', 'obscene', 'threat', 'insult', 'identity_hate']\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "004f9252",
+   "metadata": {},
+   "source": [
+    "##  Step 1: Text Cleaning Function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8508fd4d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def clean_comment(text):\n",
+    "    text = str(text)\n",
+    "    text = html.unescape(text) \n",
+    "    text = emoji.replace_emoji(text, replace=' [EMOJI] ')  # normalize emoji\n",
+    "    text = text.replace(\"\\n\", \" \").replace(\"\\r\", \" \").replace(\"\\t\", \" \")\n",
+    "    text = text.replace(\"\n",
+    "\", \" \").replace(\"\n",
+    "\", \" \").replace(\"\t\", \" \")\n",
+    "    text = re.sub(r\"http\\S+\", \"[URL]\", text)  \n",
+    "    text = re.sub(r\"\\s+\", \" \", text) \n",
+    "    return text.strip().strip('\"').strip(\"'\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b75f1d68",
+   "metadata": {},
+   "source": [
+    "## Step 2: Prepare Balanced Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c9ab8cac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def prepare_balanced_dataset(filepath, toxic_labels=TOXIC_LABELS, random_seed=42):\n",
+    "    df = pd.read_csv(filepath)\n",
+    "\n",
+    "    print(f\"📦 Original dataset shape: {df.shape}\")\n",
+    "\n",
+    "    # drop missing labels\n",
+    "    df = df.dropna(subset=toxic_labels).copy()\n",
+    "\n",
+    "    # clean text\n",
+    "    df['comment_text'] = df['comment_text'].apply(clean_comment)\n",
+    "\n",
+    "    # log content analysis\n",
+    "    emoji_count = df['comment_text'].str.contains(r'\\[EMOJI\\]', regex=True).sum()\n",
+    "    html_count = df['comment_text'].str.contains(r'&[a-z]+;', regex=True).sum()\n",
+    "    url_count = df['comment_text'].str.contains(r'http\\S+', regex=True).sum()\n",
+    "\n",
+    "    print(f\" Comments with [EMOJI]: {emoji_count}\")\n",
+    "    print(f\" Comments with HTML entities: {html_count}\")\n",
+    "    \n",
+    "    print(f\" Comments with URLs: {url_count}\")\n",
+    "\n",
+    "    # balance data\n",
+    "    df[\"num_labels\"] = df[toxic_labels].sum(axis=1)\n",
+    "    toxic_df = df[df[\"num_labels\"] > 0]\n",
+    "    non_toxic_df = df[df[\"num_labels\"] == 0].sample(n=len(toxic_df), random_state=random_seed)\n",
+    "\n",
+    "    print(f\"✅ Toxic comments: {len(toxic_df)}\")\n",
+    "    print(f\"✅ Non-toxic sampled: {len(non_toxic_df)}\")\n",
+    "\n",
+    "    balanced_df = pd.concat([toxic_df, non_toxic_df]).sample(frac=1, random_state=random_seed).reset_index(drop=True)\n",
+    "    print(f\"🎯 Final balanced dataset: {len(balanced_df)} rows\")\n",
+    "\n",
+    "    return balanced_df\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "945f3da0",
+   "metadata": {},
+   "source": [
+    "## Step 3: Load and Run"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c22da2d3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load and balance dataset\n",
+    "balanced_df = prepare_balanced_dataset(\"train.csv\")\n",
+    "balanced_df.head()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
- Cleans the Jigsaw toxic comment dataset using HTML decoding, emoji normalization, newline/URL handling
- Replaces emojis with [EMOJI], and URLs with [URL]
- Balances the dataset by sampling equal toxic and non-toxic examples
- Logs dataset stats (e.g., emoji count, HTML presence)
- Returns a cleaned dataframe


